### PR TITLE
optimize pr create and pr merge flow

### DIFF
--- a/aiwflow_issue_desc_test.sh
+++ b/aiwflow_issue_desc_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+script_dir="$(dirname "$0")"
+source $script_dir/base.sh
+
+jira_ticket=$1
+
+issue_json=$(aiwflow issue-desc $jira_ticket)
+issue_desc=$(echo "$issue_json" | jq -r '.issue_desc')
+need_translate=$(echo "$issue_json" | jq -r '.need_translate')
+translated_desc=$(echo "$issue_json" | jq -r '.translated_desc')
+
+if [ "$issue_desc" != "null" ]; then
+    echo -e $y 'PR title: '$issue_desc
+    if [ "$need_translate" = "true" ]; then
+        if [ "$translated_desc" != "null" ]; then
+            issue_desc=$translated_desc
+            echo -e $y 'Chat GPT translated: '$translated_desc
+        else
+
+            echo -e $n 'Chat GPT translated failed, but it dose not affect the use.'
+        fi
+    fi
+else
+    issue_desc=""
+fi
+
+echo $issue_desc
+
+while [ -z "$issue_desc" ]; do
+    read -p 'PR title and git branch name (require) : ' issue_desc
+done

--- a/pr-create.sh
+++ b/pr-create.sh
@@ -24,8 +24,25 @@ if [ -n "${jira_ticket}" ]; then
 fi
 
 if [ -n "${jira_ticket}" ]; then
-    issue_desc=$(aiwflow pr-create $jira_ticket)
-    echo -e $y 'PR title: '$issue_desc
+    issue_json=$(aiwflow issue-desc $jira_ticket)
+    issue_desc=$(echo "$issue_json" | jq -r '.issue_desc')
+    need_translate=$(echo "$issue_json" | jq -r '.need_translate')
+    translated_desc=$(echo "$issue_json" | jq -r '.translated_desc')
+
+    if [ "$issue_desc" != "null" ]; then
+        echo -e $y 'PR title: '$issue_desc
+        if [ "$need_translate" = "true" ]; then
+            if [ "$translated_desc" != "null" ]; then
+                issue_desc=$translated_desc
+                echo -e $y 'Chat GPT translated: '$translated_desc
+            else
+
+                echo -e $n 'Chat GPT translated failed, but it dose not affect the use.'
+            fi
+        fi
+    else
+        issue_desc=""
+    fi
 fi
 
 while [ -z "$issue_desc" ]; do

--- a/pr-merge.sh
+++ b/pr-merge.sh
@@ -14,15 +14,13 @@ if [ -z "$pr_id" ]; then
     pr_url=$(gh pr status --json url -q '.currentBranch.url')
     pr_id=$(echo "$pr_url" | grep -oE '[0-9]+$')
     if [ -n $"$pr_id" ]; then
-        echo -e $y Find current branch PR id: $pr_id
+        echo -e $y Find current branch PR: $pr_url
     fi
 fi
 
 while [ -z "$pr_id" ]; do
     read -p 'PR id(require): ' pr_id
 done
-
-gh browse $pr_id
 
 echo 'Do you want to continue merging PR? (y/n)'
 


### PR DESCRIPTION
1. No hindering users from using when they do not provide an open AI key
2. Add a check print when Chat GPT translates the PR title
3. Show the found PR URL instead of opening the browser on Github when the PR merge
4. Users can input `echo y | pr-merge` quickly and do not need to input confirm again